### PR TITLE
Dcj/218991

### DIFF
--- a/antora-playbook-de.yml
+++ b/antora-playbook-de.yml
@@ -8,7 +8,37 @@ content:
     start_path: docs/de-de
 asciidoc:
   attributes:
+    # General
+    icons: font
+    linkattrs:
+    sectnums:
+    numbered:
+    toc: right
+    toclevels: 5
+    xrefstyle: short
+    source-highlighter: highlightjs
+    example-caption!:
+    stem: latexmath
+    # Extensions
     tabs: tabs
+    # L10N
+    appendix-caption: Anhang
+    caution-caption: Achtung
+    chapter-label: Kapitel
+    example-caption: Beispiel
+    figure-caption: Bild
+    important-caption: Wichtig
+    last-update-label: Zuletzt aktualisiert
+    listing-caption: Listing
+    manname-title: BEZEICHNUNG
+    note-caption: Anmerkung
+    preface-title: Vorwort
+    table-caption: Tabelle
+    tip-caption: Hinweis
+    toc-title: Inhalt
+    untitled-label: Ohne Titel
+    version-label: Version
+    warning-caption: Warnung
   extensions:
   - ./lib/tabs-block.js
 output:

--- a/antora-playbook-de.yml
+++ b/antora-playbook-de.yml
@@ -8,6 +8,9 @@ content:
     start_path: docs/de-de
 asciidoc:
   attributes:
+    # Organisation
+    copyright: © 2021 plentysystems AG
+    orgname: plentysystems AG
     # General
     icons: font
     linkattrs:

--- a/antora-playbook-en.yml
+++ b/antora-playbook-en.yml
@@ -8,6 +8,9 @@ content:
     start_path: docs/en-gb
 asciidoc:
   attributes:
+    # Organisation
+    copyright: © 2021 plentysystems AG
+    orgname: plentysystems AG
     # General
     icons: font
     linkattrs:

--- a/antora-playbook-en.yml
+++ b/antora-playbook-en.yml
@@ -8,6 +8,18 @@ content:
     start_path: docs/en-gb
 asciidoc:
   attributes:
+    # General
+    icons: font
+    linkattrs:
+    sectnums:
+    numbered:
+    toc: right
+    toclevels: 5
+    xrefstyle: short
+    source-highlighter: highlightjs
+    example-caption!:
+    stem: latexmath
+    # Extensions
     tabs: tabs
   extensions:
   - ./lib/tabs-block.js

--- a/local-antora-playbook-de.yml
+++ b/local-antora-playbook-de.yml
@@ -8,7 +8,37 @@ content:
       start_path: adocOutput/de
 asciidoc:
   attributes:
+    # General
+    icons: font
+    linkattrs:
+    sectnums:
+    numbered:
+    toc: right
+    toclevels: 5
+    xrefstyle: short
+    source-highlighter: highlightjs
+    example-caption!:
+    stem: latexmath
+    # Extensions
     tabs: tabs
+    # L10N
+    appendix-caption: Anhang
+    caution-caption: Achtung
+    chapter-label: Kapitel
+    example-caption: Beispiel
+    figure-caption: Bild
+    important-caption: Wichtig
+    last-update-label: Zuletzt aktualisiert
+    listing-caption: Listing
+    manname-title: BEZEICHNUNG
+    note-caption: Anmerkung
+    preface-title: Vorwort
+    table-caption: Tabelle
+    tip-caption: Hinweis
+    toc-title: Inhalt
+    untitled-label: Ohne Titel
+    version-label: Version
+    warning-caption: Warnung
 output:
   dir: ./build/de
 ui:

--- a/local-antora-playbook-de.yml
+++ b/local-antora-playbook-de.yml
@@ -8,6 +8,9 @@ content:
       start_path: adocOutput/de
 asciidoc:
   attributes:
+    # Organisation
+    copyright: © 2021 plentysystems AG
+    orgname: plentysystems AG
     # General
     icons: font
     linkattrs:

--- a/local-antora-playbook-en.yml
+++ b/local-antora-playbook-en.yml
@@ -8,6 +8,9 @@ content:
       start_path: adocOutput/en
 asciidoc:
   attributes:
+    # Organisation
+    copyright: © 2021 plentysystems AG
+    orgname: plentysystems AG
     # General
     icons: font
     linkattrs:

--- a/local-antora-playbook-en.yml
+++ b/local-antora-playbook-en.yml
@@ -8,6 +8,18 @@ content:
       start_path: adocOutput/en
 asciidoc:
   attributes:
+    # General
+    icons: font
+    linkattrs:
+    sectnums:
+    numbered:
+    toc: right
+    toclevels: 5
+    xrefstyle: short
+    source-highlighter: highlightjs
+    example-caption!:
+    stem: latexmath
+    # Extensions
     tabs: tabs
 output:
   dir: ./build/en


### PR DESCRIPTION
Adds the global attributes from the old header to the playbooks. I hope the annotations are enough to give it some structure, but I'm open to other ideas.

The PDF specific attributes are missing because we won't need them for the time being.