### PR TITLE
fix: pagination

### DIFF
--- a/docs/de-de/modules/crm/pages/kontakt-bearbeiten.adoc
+++ b/docs/de-de/modules/crm/pages/kontakt-bearbeiten.adoc
@@ -1,12 +1,8 @@
 = Kontakt bearbeiten
 :keywords: Adresse, primäre Lieferadresse, primäre Rechnungsadresse, Firmen, Firma, Ustidnummer, Ust ID Nummer, Handelsvertreter, Gastzugang, Gastbestellung, eingeloggter Kunde, registrierter Kunde, regulärer Zugang, Passwort ändern, Passwortänderung, Kunde kann sich nicht einloggen, Login entsperren, Bankdaten, Kundendaten löschen, Datensatz löschen, Kunde löschen, Kontakt löschen, Adresslayout, Kundentyp, Rabattsystem, Rabatte vergeben, Rabatte für Kundenklasse, Kontaktoption, Adressoption, Provision, Kostenstelle, Kontakte importieren, Kundendaten importieren, Kundendaten exportieren, plentyShop-Login, Firma, Kontaktoptionen
+:page-pagination:
 :id: D7GKDHM
 :author: team-crm
-
-[.previous-navigation]
-xref:crm:kontakt-erstellen.adoc#[icon:long-arrow-left[] Kontakt erstellen]
-
-'''
 
 Sobald du einen Kontakt xref:crm:kontakt-erstellen.adoc#[erstellt] hast, kannst du weitere Informationen in den <<#erlaeuterungen-einzelne-bereiche, verschiedenen Bereichen des Kontaktdatensatzes>> ergänzen. Dazu kannst du eine <<#ansicht-bearbeiten, individuelle Ansicht>> erstellen oder eine der <<#standardansichten-vorlagen, Vorlagen>> verwenden, die standardmäßig in deinem System vorhanden sind.
 
@@ -1651,8 +1647,3 @@ Das Format für den Export erstellst du im Menü *Daten » FormatDesigner*. Eine
 Dir stehen zahlreiche Filteroptionen für den Export zur Verfügung. Exportiere z.B. nur Kontakte, die du mit 3 Sternen bewertet hast, oder nur Kontakte, die einem bestimmten Eigner zugeordnet sind.
 
 Importiere oder aktualisiere die Daten deiner Kontakte inklusive Adressoptionen, Kontaktoptionen und Firmendaten über das Import-Tool. Nutze dazu den Import-Typ xref:daten:elasticSync-kontakte.adoc#[Kontakte, Firmen und Adressen]. Weitere Informationen findest du auf der Handbuchseite xref:daten:ElasticSync.adoc#[Import-Tool nutzen].
-
-'''
-
-[.previous-next-navigation]
-xref:crm:kontakt-erstellen.adoc#[icon:long-arrow-left[] Kontakt erstellen]

--- a/docs/de-de/modules/crm/pages/kontakt-erstellen.adoc
+++ b/docs/de-de/modules/crm/pages/kontakt-erstellen.adoc
@@ -1,13 +1,8 @@
 = Kontakt erstellen
 :keywords: Kontakt erstellen, Kontaktdatensatz erstellen, Kunde erstellen, Kundenkonto erstellen
+:page-pagination:
 :id: AD7ZEFD
 :author: team-crm
-
-[.previous-next-navigation]
-xref:crm:kontakt-suchen.adoc#[icon:long-arrow-left[] Kontakt suchen]
-xref:crm:kontakt-bearbeiten.adoc#[Kontakt bearbeiten icon:long-arrow-right[]]
-
-'''
 
 Du möchtest ganz einfach, schnell und mit einer individuell anpassbaren Bedienoberfläche neue Kontakte zum Beispiel während eines Telefonats erstellen? Richte dir zunächst eine <<#ansicht-einrichten, neue Ansicht>> ganz nach deinen Wünschen ein.
 
@@ -306,9 +301,3 @@ Die Logik funktioniert folgendermaßen:
 * Beim Erstellen eines neuen Kontakts wird nach einem vorhandenen regulären Kontakt mit identischer privater E-Mail-Adresse gesucht. Wird ein Kontakt gefunden, wird dieser mit den neuen Daten aktualisiert. Wird _kein_ Kontakt gefunden, wird ein neuer regulärer Kontakt erstellt.
 
 * Wenn beim Aktualisieren eines bestehenden regulären Kontaktes die private E-Mail-Adresse geändert wird, wird zunächst gesucht, ob ein anderer regulärer Kontakt mit derselben privaten E-Mail-Adresse existiert. Ist dies der Fall, wird die private E-Mail-Adresse des aktuellen Kontaktes _nicht_ aktualisiert, alle anderen Daten jedoch schon.
-
-'''
-
-[.previous-next-navigation]
-xref:crm:kontakt-suchen.adoc#[icon:long-arrow-left[] Kontakt suchen]
-xref:crm:kontakt-bearbeiten.adoc#[Kontakt bearbeiten icon:long-arrow-right[]]

--- a/docs/de-de/modules/crm/pages/kontakt-suchen.adoc
+++ b/docs/de-de/modules/crm/pages/kontakt-suchen.adoc
@@ -1,13 +1,8 @@
 = Kontakt suchen
 :keywords: Kontakt suchen, Kontaktsuche, Kunden suchen, Kunde suchen, Kontakt finden, Gast suchen
+:page-pagination:
 :id: LAWRQ5I
 :author: team-crm
-
-[.previous-next-navigation]
-xref:crm:vorbereitende-einstellungen.adoc#[icon:long-arrow-left[] Vorbereitende Einstellungen vornehmen]
-xref:crm:kontakt-erstellen.adoc#[Kontakt erstellen icon:long-arrow-right[]]
-
-'''
 
 Um einen bestimmten Kontakt zu suchen, gibst du die dir bekannten Suchbegriffe in die Filter ein. Es ist auch möglich, mehrere Suchbegriffe gleichzeitig in die Suchfelder einzugeben. Dies ermöglicht eine schnellere und genauere Suche.
 
@@ -227,9 +222,3 @@ TODO:hier später die neue Messenger-Seite verlinken
 
 * material:delete[] *Kontakt löschen*
 ** xref:crm:kontakt-bearbeiten.adoc#kontakt-loeschen[Löscht] den Kontakt nach dem Bestätigen der Sicherheitsabfrage.
-
-'''
-
-[.previous-next-navigation]
-xref:crm:vorbereitende-einstellungen.adoc#[icon:long-arrow-left[] Vorbereitende Einstellungen vornehmen]
-xref:crm:kontakt-erstellen.adoc#[Kontakt erstellen icon:long-arrow-right[]]

--- a/docs/de-de/modules/crm/pages/vorbereitende-einstellungen.adoc
+++ b/docs/de-de/modules/crm/pages/vorbereitende-einstellungen.adoc
@@ -1,12 +1,8 @@
 = Vorbereitende Einstellungen vornehmen
 :keywords: Adress-Layout, Adresslayout, Adresslayout Lieferschein, Kundenklasse, Kontaktklasse, Kundentyp, Typ, Kundenklasse erstellen, Typ erstellen, Eigenschaften für Kontakt erstellen, Kundeneigenschaften, Kunden Eigenschaften auf Dokumenten, Tags für Kontakte, Tags für Kunden, Kontakttags, Kunden-Tags, Rabattsystem, Rabatt auf Kundenklasse, Kundenklassenrabatt, Rabattstaffel auf Nettowarenwert, Rabatt auf Zahlungsart, Verkaufspreis als Rabatt, manueller Rabatt für Kunden, manueller Rabatt für Kontakte, Rabatt für Kunden gewähren
+:page-pagination:
 :id: V71KF8L
 :author: team-crm
-
-[.next-navigation]
-xref:crm:kontakt-suchen.adoc#[Kontakt suchen icon:long-arrow-right[]]
-
-'''
 
 Du musst einige vorbereitende Einstellungen vornehmen, damit du die Kontaktverwaltung im Menü *CRM » Kontakte* optimal nutzen kannst.
 
@@ -608,8 +604,3 @@ Rabatt für alle Artikel eines Auftrags eingeben:
 . Wähle aus der angezeigten Dropdown-Liste den Rabattsatz.
 . Klicke rechts neben der Dropdown-Liste auf *Speichern*.
 . *Speichere* (icon:save[role="green"]) die Einstellungen.
-
-'''
-
-[.next-navigation]
-xref:crm:kontakt-suchen.adoc#[Kontakt suchen icon:long-arrow-right[]]

--- a/docs/de-de/modules/maerkte/pages/_amazon-katalog-validierung.adoc
+++ b/docs/de-de/modules/maerkte/pages/_amazon-katalog-validierung.adoc
@@ -2,14 +2,9 @@
 :keywords: Kataloge validieren, Katalogvalidierung, Katalog validieren, Katalogexport validieren, Katalog prüfen, Kataloge prüfen
 :page-index: false
 :page-aliases: katalogexport-pruefen.adoc
+:page-pagination:
 :id: 307GEZD
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:maerkte:variantendaten-exportieren.adoc#[icon:long-arrow-left[] Amazon-Variantenexport per Katalog einrichten]
-xref:maerkte:fulfillment.adoc#[Fulfillment einrichten icon:long-arrow-right[]]
-
-'''
 
 Katalogexporte kannst du mit dem Tool plentyBI prüfen. Zurzeit stehen für den Marktplatz Amazon die folgenden Kennzahlen für Katalogexporte zur Verfügung:
 
@@ -35,9 +30,3 @@ include::partial$BI-catalogue-variationvalidation.adoc[]
 :market: Amazon
 
 include::partial$BI-catalogue-stockinformation.adoc[]
-
-'''
-
-[.previous-next-navigation]
-xref:maerkte:variantendaten-exportieren.adoc#[icon:long-arrow-left[] Amazon-Variantenexport per Katalog einrichten]
-xref:maerkte:fulfillment.adoc#[Fulfillment einrichten icon:long-arrow-right[]]

--- a/docs/de-de/modules/maerkte/pages/amazon-einrichten.adoc
+++ b/docs/de-de/modules/maerkte/pages/amazon-einrichten.adoc
@@ -1,13 +1,9 @@
 = Amazon einrichten
 :keywords: Amazon, Amazon einrichten, FBA, Amazon FBA, Fulfillment by Amazon, MFN, Amazon MFN, Merchant Fulfillment Network, Prime, SameDay, NextDay, SecondDay, Marktplatz, Multi-Channel, Multichannel, Amazon Multi-Channel, Multi-Channel Amazon, Amazon Business, Amazon B2B, Amazon VCS, VCS, VCS Lite, IDU, Invoice Document Uploader, Amazon Rechnung, Umsatzsteuerservice, Amazon Pay, Amazon Produkttyp, Flat File, Flatfile, Lagerbestandsdatei, ASIN, ASIN-Verknüpfung, Amazon-Plattform, amazon.de, Autorisierung, Gutschriftenimport, VCS plentymarkets, VCS Amazon
 :description: Multi-Channel in plentymarkets: Richte die Schnittstelle zum Marktplatz Amazon in deinem plentymarkets System ein.
+:page-pagination:
 :id: GL6NEIV
 :author: team-plenty-channel
-
-[.next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[Varianten vorbereiten icon:long-arrow-right[]]
-
-'''
 
 link:https://www.amazon.de/[Amazon^] hat sich von der größten Online-Buchhandlung zum führenden Universalkaufhaus entwickelt. Unzählige Kund:innen schätzen die große Auswahl, vertrauen auf eine hohe Warenqualität und erwarten besten Service wie zum Beispiel eine sehr zeitnahe Warenlieferung. plentymarkets ermöglicht dir die komplette und integrierte Anbindung an Amazon. Erfahre, wie du Artikel verfügbar machst, den Datenaustausch über die Schnittstelle aktivierst, den FBA-Service von Amazon nutzt und vieles mehr. FBA ist das Kürzel für Fulfillment by Amazon, einem Service von Amazon, bei dem Amazon die Lagerhaltung sowie die gesamte Logistik übernimmt.
 
@@ -457,8 +453,3 @@ Die FAQ zum Thema Preis- und Bestandsabgleich sind umgezogen. Du findest diese I
 == Nächste Schritte
 
 Nachdem du nun die Schnittstelle zu Amazon in plentymarkets eingerichtet hast, bereitest du als Nächstes xref:maerkte:varianten-vorbereiten.adoc#[deine Varianten für den Export zu Amazon vor].
-
-'''
-
-[.next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[Varianten vorbereiten icon:long-arrow-right[]]

--- a/docs/de-de/modules/maerkte/pages/amazon-fulfillment.adoc
+++ b/docs/de-de/modules/maerkte/pages/amazon-fulfillment.adoc
@@ -2,19 +2,9 @@
 :keywords: Amazon FBA, FBA, FBA-Aufträge, FBA-Auftrag, MFN, Versand von Amazon-Aufträgen, Amazon Versand
 :description: Multi-Channel in plentymarkets: Bereite deinen Versand für Amazon-Aufträge vor.
 :page-aliases: fulfillment.adoc
+:page-pagination:
 :id: QYFYPFT
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:maerkte:variantendaten-exportieren.adoc#[icon:long-arrow-left[] Amazon-Variantenexport per Katalog einrichten]
-xref:maerkte:amazon-fba-nutzen.adoc#[FBA-Service von Amazon nutzen icon:long-arrow-right[]]
-
-[.text-left]
-_oder_
-
-xref:maerkte:variantendaten-exportieren-alt.adoc#[icon:long-arrow-left[] Variantenexport über alte Technologie einrichten]
-
-'''
 
 Den Versand von Varianten, die du über Amazon verkaufst, kannst du auf verschiedene Arten organisieren:
 
@@ -122,14 +112,3 @@ Wenn du weitere Amazon-Services nutzen möchtest:
 * xref:maerkte:amazon-business-einrichten.adoc#[Amazon Business einrichten]
 * xref:maerkte:amazon-pay-einrichten.adoc#[Amazon Pay einrichten]
 * xref:maerkte:AmazonVCSDashboard.adoc#[Plugin AmazonVCSDashboard nutzen]
-
-'''
-
-[.previous-next-navigation]
-xref:maerkte:variantendaten-exportieren.adoc#[icon:long-arrow-left[] Amazon-Variantenexport per Katalog einrichten]
-xref:maerkte:amazon-fba-nutzen.adoc#[FBA-Service von Amazon nutzen icon:long-arrow-right[]]
-
-[.text-left]
-_oder_
-
-xref:maerkte:variantendaten-exportieren-alt.adoc#[icon:long-arrow-left[] Variantenexport über alte Technologie einrichten]

--- a/docs/de-de/modules/maerkte/pages/varianten-exportieren-datenexport.adoc
+++ b/docs/de-de/modules/maerkte/pages/varianten-exportieren-datenexport.adoc
@@ -2,14 +2,9 @@
 :keywords: Export Amazon, Amazon Export, Amazon Artikelexport, Amazon Variantenexport
 :description: Multi-Channel in plentymarkets: Exportiere deine Variantendaten an den Marktplatz Amazon.
 :page-aliases: variantendaten-exportieren-alt.adoc
+:page-pagination:
 :id: 0ZI4W16
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[icon:long-arrow-left[] Varianten vorbereiten]
-xref:maerkte:fulfillment.adoc#[Fulfillment einrichten icon:long-arrow-right[]]
-
-'''
 
 Auf dieser Seite erfährst du, wie du den Export von Varianten einrichtest und startest, wenn du noch nicht mit den neuen Katalogen arbeiten möchtest.
 
@@ -239,9 +234,3 @@ Wenn du weitere Amazon-Services nutzen möchtest:
 Wenn was schiefgegangen ist:
 
 * xref:maerkte:amazon-faq-sammlung.adoc#[Liste der FAQs und Lösungen]
-
-'''
-
-[.previous-next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[icon:long-arrow-left[] Varianten vorbereiten]
-xref:maerkte:amazon-fba-nutzen.adoc#[FBA-Service von Amazon nutzen icon:long-arrow-right[]]

--- a/docs/de-de/modules/maerkte/pages/varianten-exportieren-katalog.adoc
+++ b/docs/de-de/modules/maerkte/pages/varianten-exportieren-katalog.adoc
@@ -2,14 +2,9 @@
 :keywords: Amazon Katalog, Export Amazon, Amazon Export
 :description: Multi-Channel in plentymarkets: Erstelle einen Katalog für den Export von Variantendaten an den Marktplatz Amazon.
 :page-aliases: variantendaten-exportieren.adoc
+:page-pagination:
 :id: EABQJ7Y
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[icon:long-arrow-left[] Varianten vorbereiten]
-xref:maerkte:fulfillment.adoc#[Fulfillment einrichten icon:long-arrow-right[]]
-
-'''
 
 Es ist so weit: Der Amazon-Katalog ist da! Mit Amazon ziehen wir den ersten großen Marktplatz auf die Kataloge um. Bis auf weiteres kannst du aber auch weiterhin den alten Export nutzen.
 
@@ -351,9 +346,3 @@ Wenn du weitere Amazon-Services nutzen möchtest:
 Wenn was schiefgegangen ist:
 
 * xref:maerkte:amazon-faq-sammlung.adoc#[Liste der FAQs und Lösungen]
-
-'''
-
-[.previous-next-navigation]
-xref:maerkte:varianten-vorbereiten.adoc#[icon:long-arrow-left[] Varianten vorbereiten]
-xref:maerkte:fulfillment.adoc#[Fulfillment einrichten icon:long-arrow-right[]]

--- a/docs/de-de/modules/maerkte/pages/varianten-vorbereiten.adoc
+++ b/docs/de-de/modules/maerkte/pages/varianten-vorbereiten.adoc
@@ -1,20 +1,9 @@
 = Amazon: Varianten vorbereiten
 :keywords: Amazon einrichten, FBA, Amazon FBA, Fulfillment by Amazon, MFN, Amazon MFN, Merchant Fulfillment Network, Prime, SameDay, NextDay, SecondDay, Marktplatz, Multi-Channel, Multichannel, Amazon Multi-Channel, Multi-Channel Amazon, Amazon Business, Amazon B2B, Amazon VCS, VCS, VCS Lite, IDU, Invoice Document Uploader, Amazon Rechnung, Umsatzsteuerservice, Amazon Pay, Amazon Produkttyp, Flat File, Flatfile, Lagerbestandsdatei, Amazon-Plattform, amazon.de
 :description: Multi-Channel in plentymarkets: Bereite deine Varianten für den Marktplatz Amazon vor.
+:page-pagination:
 :id: YJ18JF6
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:maerkte:amazon-einrichten.adoc#[icon:long-arrow-left[] Amazon in plentymarkets einrichten]
-xref:maerkte:variantendaten-exportieren.adoc#[Amazon-Variantenexport per Katalog einrichten icon:long-arrow-right[]]
-
-[.text-right]
-_oder_
-
-[.next-navigation]
-xref:maerkte:variantendaten-exportieren-alt.adoc#[Variantenexport über alte Technologie einrichten icon:long-arrow-right[]]
-
-'''
 
 Du hast die Schnittstelle zu Amazon xref:maerkte:amazon-einrichten.adoc#[eingerichtet]? Super. Dann bereite nun deine Varianten für den Export zu Amazon vor.
 
@@ -596,15 +585,3 @@ Du hast nun die Schnittstelle zu Amazon in plentymarkets eingerichtet und deine 
 
 * xref:maerkte:variantendaten-exportieren.adoc#[Amazon-Variantenexport per Katalog einrichten]
 * xref:maerkte:variantendaten-exportieren-alt.adoc#[Variantenexport über alte Technologie einrichten]
-
-'''
-
-[.previous-next-navigation]
-xref:maerkte:amazon-einrichten.adoc#[icon:long-arrow-left[] Amazon in plentymarkets einrichten]
-xref:maerkte:variantendaten-exportieren.adoc#[Amazon-Variantenexport per Katalog einrichten icon:long-arrow-right[]]
-
-[.text-right]
-_oder_
-
-[.next-navigation]
-xref:maerkte:variantendaten-exportieren-alt.adoc#[Variantenexport über alte Technologie einrichten icon:long-arrow-right[]]

--- a/docs/de-de/modules/plugins/pages/hinzugefuegte-plugins-installieren.adoc
+++ b/docs/de-de/modules/plugins/pages/hinzugefuegte-plugins-installieren.adoc
@@ -2,13 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, erweiterung, addon, plugin-set, mandant, backend-plugin-set
 :description: Alles zur Installation von Plugins und dem Verknüpfen mit Mandanten und Benutzerkonten.
+:page-pagination:
 :id: EGDTDOH
-
-[.previous-next-navigation]
-xref:plugins:plugins-system-hinzufuegen.adoc#[icon:long-arrow-left[] Plugins dem System hinzufügen]
-xref:plugins:installierte-plugins-konfigurieren.adoc#[Installierte Plugins konfigurieren icon:long-arrow-right[]]
-
-'''
 
 Um Plugins nutzen zu können, musst du sie zunächst in einem Plugin-Set einbinden und das Plugin-Set bereitstellen. <<plugin-set-erstellen, Erstelle oder kopiere>> zunächst ein neues Plugin-Set. Dort kannst du das Plugin <<plugin-installieren, installieren und bereitstellen>>. Um das Plugin zu nutzen, verknüpfst du es abschließend noch mit einem <<plugin-set-verknuepfen, Mandanten>> oder <<backend-plugin-set, Benutzerkonto>>.
 
@@ -21,9 +16,3 @@ include::partial$chapter-plugin-in-set-installieren.adoc[]
 include::partial$chapter-plugin-set-live-schalten.adoc[]
 
 include::partial$chapter-plugin-set-benutzerkonto-verknuepfen.adoc[]
-
-'''
-
-[.previous-next-navigation]
-xref:plugins:plugins-system-hinzufuegen.adoc#[icon:long-arrow-left[] Plugins dem System hinzufügen]
-xref:plugins:installierte-plugins-konfigurieren.adoc#[Installierte Plugins konfigurieren icon:long-arrow-right[]]

--- a/docs/de-de/modules/plugins/pages/installierte-plugins-konfigurieren.adoc
+++ b/docs/de-de/modules/plugins/pages/installierte-plugins-konfigurieren.adoc
@@ -2,12 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, erweiterung, addon, container, konfiguration
 :description: Optionen zum Konfigurieren von Plugins.
+:page-pagination:
 :id: H4HJIKA
-
-[.previous-navigation]
-xref:plugins:hinzugefuegte-plugins-installieren.adoc#[icon:long-arrow-left[] Hinzugefügte Plugins installieren]
-
-'''
 
 Auf dieser Seite findest du Themen, die die Konfiguration von Plugins allgemein betreffen. Dazu gehören der <<lokale-vs-globale-konfiguration,Unterschied zwischen lokalen und globalen Einstellungen>> sowie das <<konfiguration-exportieren-importieren,Exportieren und Importieren von lokalen Konfigurationen>>. Außerdem werden <<container-verknuepfungen,Container-Verknüpfungen>> erläutert.
 include::partial$container-verknuepfung.adoc[]
@@ -21,8 +17,3 @@ include::partial$chapter-konfiguration-exportieren-importieren.adoc[]
 include::partial$chapter-container-verknuepfungen.adoc[]
 
 :leveloffset: -1
-
-'''
-
-[.previous-navigation]
-xref:plugins:hinzugefuegte-plugins-installieren.adoc#[icon:long-arrow-left[] Hinzugefügte Plugins installieren]

--- a/docs/de-de/modules/plugins/pages/plugins-system-hinzufuegen.adoc
+++ b/docs/de-de/modules/plugins/pages/plugins-system-hinzufuegen.adoc
@@ -2,12 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, erweiterung, addon, git, github, bitbucket, gitlab, integrationen, plentymarketplace
 :description: Finde heraus, wie du Plugins zu deinem System hinzufügen kannst.
+:page-pagination:
 :id: BZCJL1G
-
-[.next-navigation]
-xref:plugins:hinzugefuegte-plugins-installieren.adoc#[Hinzugefügte Plugins installieren icon:long-arrow-right[]]
-
-'''
 
 Du hast verschiedene Möglichkeiten, um Plugins zu deinem plentymarkets System hinzuzufügen. Mit dem <<integrationen-assistent, Integrationen-Assistenten>> setzt du schnell und unkompliziert deinen Webshop auf. Über <<marketplace-plugins, plentyMarketplace>> kannst Plugins sowohl kostenlos als auch kostenpflichtig erwerben. Benötigst du ein Plugin, das speziell auf deine Anforderungen zugeschnitten ist, steht dir das <<git-plugins, Hinzufügen über Git>> zu Verfügung.
 
@@ -20,8 +16,3 @@ include::partial$chapter-marketplace-plugins.adoc[]
 include::partial$chapter-git-plugins.adoc[]
 
 :leveloffset: -1
-
-'''
-
-[.next-navigation]
-xref:plugins:hinzugefuegte-plugins-installieren.adoc#[Hinzugefügte Plugins installieren icon:long-arrow-right[]]

--- a/docs/de-de/modules/plugins/pages/plugins.adoc
+++ b/docs/de-de/modules/plugins/pages/plugins.adoc
@@ -1,4 +1,5 @@
 = Plugins
+:page-pagination:
 :author: team-plugin-core
 :pos: plugins
 :id: XPOMS9R
@@ -16,8 +17,3 @@ include::plugins:partial$anzahl-erlaubter-plugin-sets.adoc[]
 * Benötigst du eine bestimmte Funktionalität und wirst auf Marketplace nicht fündig, stelle dein Anliegen in der link:https://marketplace.plentymarkets.com/plentyprojects/[Projektbörse^] ein und erarbeite zusammen mit einer unserer link:https://marketplace.plentymarkets.com/partners[Partneragenturen^] eine Lösung. Oder...
 * Erstelle deine eigenen Plugins. Mehr Informationen dazu findest du auf link:http://developers.plentymarkets.com/[plentyDevelopers^].
 ====
-
-'''
-
-[.next-navigation]
-xref:plugins:plugins-system-hinzufuegen.adoc#[Plugins dem System hinzufügen icon:long-arrow-right[]]

--- a/docs/en-gb/modules/crm/pages/create-contact.adoc
+++ b/docs/en-gb/modules/crm/pages/create-contact.adoc
@@ -1,13 +1,8 @@
 = Creating a contact
 :keywords: create contact, create contact data record, create customer, create customer account
+:page-pagination:
 :id: AD7ZEFD
 :author: team-crm
-
-[.previous-next-navigation]
-xref:crm:search-contact.adoc#[icon:long-arrow-left[] Searching for a contact]
-xref:crm:edit-contact.adoc#[Editing a contact icon:long-arrow-right[]]
-
-'''
 
 Do you want to easily and quickly create new contacts with an individually adjustable user interface, for example during a phone call? First of all, set up a <<#set-up-view, new view>> according to your needs.
 
@@ -305,9 +300,3 @@ The logic works in the following way:
 * When creating a new contact, the system searches for an existing regular contact with identical private email address. If a contact is found, this contact is updated with the new data. If _no_ contact is found, a new regular contact is created.
 
 * When updating the private email address of an existing regular contact, the system searches if another regular contact with the same private email address exists. If this is the case, the private email address of the current contact is _not_ updated. All other data, however, is updated.
-
-'''
-
-[.previous-next-navigation]
-xref:crm:search-contact.adoc#[icon:long-arrow-left[] Searching for a contact]
-xref:crm:edit-contact.adoc#[Editing a contact icon:long-arrow-right[]]

--- a/docs/en-gb/modules/crm/pages/edit-contact.adoc
+++ b/docs/en-gb/modules/crm/pages/edit-contact.adoc
@@ -1,12 +1,8 @@
 = Editing a contact
 :keywords: address, primary delivery address, primary invoice address, companies, company, VAT number, VAT no., sales representative, guest account, guest order, logged in customer, registered customer, regular access, change password, customer cannot log in, unlock login, bank details, delete customer data, delete data record, delete customer, delete contact, address layout, customer type, discount system, grant discount, discount for customer class, contact option, address option, commission, cost unit, import contact, import customer data, export customer data, plentyShop login, company, contact options
+:page-pagination:
 :id: D7GKDHM
 :author: team-crm
-
-[.previous-navigation]
-xref:crm:create-contact.adoc#[icon:long-arrow-left[] Creating a contact]
-
-'''
 
 Once you have xref:crm:create-contact.adoc#[created] a contact, you can add further details to the <<#details-individual-areas, various areas of the contact data record>>. To do so, you can <<#edit-view, create your own view>> or use one of the <<#default-views-templates, templates>> that are available in your system by default.
 
@@ -1651,8 +1647,3 @@ Create the format for the export in the *Data » FormatDesigner* menu. Create a 
 Various filter options are available for the export. You can export, for example, only contacts that you have rated with 3 stars or only contacts that are assigned to a certain owner.
 
 Import or update the data of your contacts including address options, contact options and account data via the import tool. To do so, use the import type xref:data:elasticSync-contacts.adoc#[Contacts, companies and addresses]. For further information, refer to the xref:data:ElasticSync.adoc#[Using the import tool] page of the manual.
-
-'''
-
-[.previous-next-navigation]
-xref:crm:create-contact.adoc#[icon:long-arrow-left[] Creating a contact]

--- a/docs/en-gb/modules/crm/pages/preparatory-settings.adoc
+++ b/docs/en-gb/modules/crm/pages/preparatory-settings.adoc
@@ -1,12 +1,8 @@
 = Carrying out the preparatory settings
 :keywords: address layout, address layout delivery note, customer class, contact class, customer type, type, create customer class, create type, create properties for contact, customer properties, customer properties on documents, tags for contacts, contact tags, tags for customers, customer tags, discount system, discount on customer class, customer class discount, discount on net value of items, discount on payment method, sales price as discount, manual discount for customers, manual discount for contacts, grant discount
+:page-pagination:
 :id: V71KF8L
 :author: team-crm
-
-[.next-navigation]
-xref:crm:search-contact.adoc#[Searching for a contact icon:long-arrow-right[]]
-
-'''
 
 You have to carry out some preparatory settings to be able to optimally use the contact management in the *CRM » Contacts* menu.
 
@@ -609,8 +605,3 @@ Entering a discount for all items of an order:
 . Select the percentage value from the displayed drop-down list.
 . Click on *Save* to the right of the drop-down list.
 . *Save* (icon:save[role="green"]) the settings.
-
-'''
-
-[.next-navigation]
-xref:crm:search-contact.adoc#[Searching for a contact icon:long-arrow-right[]]

--- a/docs/en-gb/modules/crm/pages/search-contact.adoc
+++ b/docs/en-gb/modules/crm/pages/search-contact.adoc
@@ -1,13 +1,8 @@
 = Searching for a contact
 :keywords: search contact, contact search, search customer, customer search, find contact, search guest
+:page-pagination:
 :id: LAWRQ5I
 :author: team-crm
-
-[.previous-next-navigation]
-xref:crm:preparatory-settings.adoc#[icon:long-arrow-left[] Carrying out the preparatory settings]
-xref:crm:create-contact.adoc#[Creating a contact icon:long-arrow-right[]]
-
-'''
 
 In order to search for specific contacts, enter a search term in the search fields. You can enter multiple search terms into the search fields at one time. This makes your search run quicker and be more accurate.
 
@@ -225,9 +220,3 @@ For further information, refer to the xref:crm:messenger.adoc#[Messenger] page.
 
 * material:delete[] Delete contact
 ** xref:crm:edit-contact.adoc#delete-contact[Deletes] the contact after confirming the security question.
-
-'''
-
-[.previous-next-navigation]
-xref:crm:preparatory-settings.adoc#[icon:long-arrow-left[] Carrying out the preparatory settings]
-xref:crm:create-contact.adoc#[Creating a contact icon:long-arrow-right[]]

--- a/docs/en-gb/modules/markets/pages/amazon-fulfilment.adoc
+++ b/docs/en-gb/modules/markets/pages/amazon-fulfilment.adoc
@@ -2,19 +2,9 @@
 :keywords: Amazon FBA, FBA, FBA orders, FBA order
 :description: Multi-Channel in plentymarkets: Amazon FBA with plentymarkets.
 :page-aliases: fulfilment.adoc
+:page-pagination:
 :id: QYFYPFT
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:markets:variation-data-export.adoc#[icon:long-arrow-left[] Setting up catalogues for variation export to Amazon]
-xref:markets:amazon-fba.adoc#[Using the FBA service by Amazon icon:long-arrow-right[]]
-
-[.text-left]
-_or_
-
-xref:markets:variation-export-old.adoc#[icon:long-arrow-left[] Setting up variation export with old technology]
-
-'''
 
 You can organise the shipping of variations sold on Amazon in different ways:
 
@@ -122,14 +112,3 @@ If you want to use additional Amazon services:
 * xref:markets:amazon-business.adoc#[Setting up Amazon Business]
 * xref:markets:amazon-pay.adoc#[Setting up Amazon Pay]
 * xref:markets:AmazonVCSDashboard.adoc#[Using the AmazonVCSDashboard plugin]
-
-'''
-
-[.previous-next-navigation]
-xref:markets:variation-data-export.adoc#[icon:long-arrow-left[] Setting up catalogues for variation export to Amazon]
-xref:markets:amazon-fba.adoc#[Using the FBA service by Amazon icon:long-arrow-right[]]
-
-[.text-left]
-_or_
-
-xref:markets:variation-export-old.adoc#[icon:long-arrow-left[] Setting up variation export with old technology]

--- a/docs/en-gb/modules/markets/pages/amazon-setup.adoc
+++ b/docs/en-gb/modules/markets/pages/amazon-setup.adoc
@@ -1,13 +1,9 @@
 = Setting up Amazon
 :keywords: Amazon, Amazon setup, setting up Amazon, FBA, Amazon FBA, Fulfillment by Amazon, MFN, Amazon MFN, Merchant Fulfillment Network, Prime, SameDay, NextDay, SecondDay, Market, Marketplace, Multi-Channel, Multichannel, Multi-Channel Amazon, Amazon Multi-Channel, Amazon Business, Amazon B2B, Amazon VCS, VCS, VCS Lite, IDU, Invoice Document Uploader, Amazon invoice, VAT calculation service, Amazon Pay, Amazon product type, flat file, flatfile, ASIN, ASIN matching, Amazon platform, amazon.de, authorisation, authentication, credit note import, VCS plentymarkets, VCS Amazon
 :description: Multi-Channel in plentymarkets: Set up the interface to the market Amazon in your plentymarkets system.
+:page-pagination:
 :id: GL6NEIV
 :author: team-plenty-channel
-
-[.next-navigation]
-xref:markets:preparing-variations.adoc#[Preparing variations icon:long-arrow-right[]]
-
-'''
 
 link:https://www.amazon.co.uk/[Amazon^] has gone from being the largest internet book store to one of the leading universal shopping centres. Many customers appreciate the large portfolio, rely on the high product quality and expect best service such as fast delivery. With plentymarkets, you have full access to Amazon. Learn how to make items available, activate the interface for data exchange, use the FBA service by Amazon and many more. The abbreviation FBA stands for Fulfilment by Amazon, a service from Amazon where Amazon takes care of the entire stock management and logistics.
 
@@ -457,8 +453,3 @@ The FAQ about price and stock synchronisation have moved. You can now find this 
 == Next steps
 
 After you have set up the interface to Amazon, it is now time to xref:markets:preparing-variations.adoc#[prepare your variations for the export to Amazon].
-
-'''
-
-[.next-navigation]
-xref:markets:preparing-variations.adoc#[Preparing variations icon:long-arrow-right[]]

--- a/docs/en-gb/modules/markets/pages/preparing-variations.adoc
+++ b/docs/en-gb/modules/markets/pages/preparing-variations.adoc
@@ -1,20 +1,9 @@
 = Amazon: Preparing variations
 :keywords: preparing variations for amazon, variations amazon, amazon variations
 :description: Multi-Channel in plentymarkets: Prepare your variations for the market Amazon.
+:page-pagination:
 :id: YJ18JF6
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:markets:amazon-setup.adoc#[icon:long-arrow-left[] Setting up Amazon in plentymarkets]
-xref:markets:variation-data-export.adoc#[Setting up catalogues for variation export to Amazon icon:long-arrow-right[]]
-
-[.text-right]
-_or_
-
-[.next-navigation]
-xref:markets:variation-export-old.adoc#[Setting up variation export with old technology icon:long-arrow-right[]]
-
-'''
 
 You have xref:markets:amazon-setup.adoc#[set up] the interface to Amazon? Great. Then get started on preparing your variations for exporting them to Amazon.
 
@@ -597,15 +586,3 @@ You have set up the interface to Amazon and have prepared your variations. Now, 
 
 * xref:markets:variation-data-export.adoc#[Setting up catalogues for variation export to Amazon]
 * xref:markets:variation-export-old.adoc#[Setting up variation export with old technology]
-
-'''
-
-[.previous-next-navigation]
-xref:markets:amazon-setup.adoc#[icon:long-arrow-left[] Setting up Amazon in plentymarkets]
-xref:markets:variation-data-export.adoc#[Setting up catalogues for variation export to Amazon icon:long-arrow-right[]]
-
-[.text-right]
-_or_
-
-[.next-navigation]
-xref:markets:variation-export-old.adoc#[Setting up variation export with old technology icon:long-arrow-right[]]

--- a/docs/en-gb/modules/markets/pages/variation-export-data-export.adoc
+++ b/docs/en-gb/modules/markets/pages/variation-export-data-export.adoc
@@ -2,14 +2,9 @@
 :keywords: Amazon, Export Amazon, Amazon Export, exporting item data to Amazon, exporting variation data to Amazon
 :description: Multi-Channel in plentymarkets: Export your variation data to the market Amazon.
 :page-aliases: variation-export-old.adoc
+:page-pagination:
 :id: 0ZI4W16
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:markets:preparing-variations.adoc#[icon:long-arrow-left[] Preparing variations]
-xref:markets:fulfilment.adoc#[Setting up fulfilment icon:long-arrow-right[]]
-
-'''
 
 This page shows you how to set up and start the export of variations if you do not want to use the new catalogues.
 
@@ -237,9 +232,3 @@ If you want to use additional Amazon services:
 If something went wrong:
 
 * xref:markets:amazon-faq-collection.adoc#[List of FAQs and solutions]
-
-'''
-
-[.previous-next-navigation]
-xref:markets:preparing-variations.adoc#[icon:long-arrow-left[] Preparing variations]
-xref:markets:amazon-fba.adoc#[Using the FBA service by Amazon icon:long-arrow-right[]]

--- a/docs/en-gb/modules/markets/pages/variation-export.adoc
+++ b/docs/en-gb/modules/markets/pages/variation-export.adoc
@@ -2,14 +2,9 @@
 :keywords: Amazon catalog, Amazon catalogue, Export Amazon, Amazon Export, exporting item data to Amazon, exporting variation data to Amazon
 :description: Multi-Channel in plentymarkets: Create a catalogue to export variation data to the market Amazon.
 :page-aliases: variation-data-export.adoc
+:page-pagination:
 :id: EABQJ7Y
 :author: team-plenty-channel
-
-[.previous-next-navigation]
-xref:markets:preparing-variations.adoc#[icon:long-arrow-left[] Preparing variations]
-xref:markets:fulfilment.adoc#[Setting up fulfilment icon:long-arrow-right[]]
-
-'''
 
 The Amazon catalogue is here! Amazon is the first big market to be offered for variation export via catalogues. However, if you prefer you can still use the old export.
 
@@ -348,9 +343,3 @@ If you want to use additional Amazon services:
 If something went wrong:
 
 * xref:markets:amazon-faq-collection.adoc#[List of FAQs and solutions]
-
-'''
-
-[.previous-next-navigation]
-xref:markets:preparing-variations.adoc#[icon:long-arrow-left[] Preparing variations]
-xref:markets:fulfilment.adoc#[Setting up fulfilment icon:long-arrow-right[]]

--- a/docs/en-gb/modules/plugins/pages/adding-plugins-system.adoc
+++ b/docs/en-gb/modules/plugins/pages/adding-plugins-system.adoc
@@ -2,12 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, extension, addon, git, github, bitbucket, gitlab, integrationen, plentymarketplace
 :description: Add plugins to your system via plentyMarketplace, Git or the integrations assistant.
+:page-pagination:
 :id: BZCJL1G
-
-[.next-navigation]
-xref:plugins:installing-added-plugins.adoc#[Installing added plugins icon:long-arrow-right[]]
-
-'''
 
 There are multiple ways of adding plugins to your plentymarkets system. Using the <<integrations-assistant, Integrations assistant>>, you can set up your online store quick and easy. You can purchase plugins on <<marketplace-plugins, plentyMarketplace>>, some for free, others for additional costs. If you need a custom plugin designed to satisfy your particular needs, you can <<git-plugins, add it via Git>>.
 
@@ -102,8 +98,3 @@ include::partial$hinzugefuegte-plugins-installieren-en_gb.adoc[]
 === Functional overview
 
 include::partial$git-repository-verwaltung-en_gb.adoc[]
-
-'''
-
-[.next-navigation]
-xref:plugins:installing-added-plugins.adoc#[Installing added plugins icon:long-arrow-right[]]

--- a/docs/en-gb/modules/plugins/pages/configuring-installed-plugins.adoc
+++ b/docs/en-gb/modules/plugins/pages/configuring-installed-plugins.adoc
@@ -2,12 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, extension, addon, container, configuration
 :description: Configure your plugins.
+:page-pagination:
 :id: H4HJIKA
-
-[.previous-navigation]
-xref:plugins:installing-added-plugins.adoc#[icon:long-arrow-left[] Installing added plugins]
-
-'''
 
 include::partial$installierte-plugins-konfigurieren-en_gb.adoc[]
 
@@ -52,8 +48,3 @@ To select container links, proceed as follows:
 include::partial$plugin-container-verknuepfung-en_gb.adoc[]
 
 include::partial$standard-container-verknuepfungen-en_gb.adoc[]
-
-'''
-
-[.previous-navigation]
-xref:plugins:installing-added-plugins.adoc#[icon:long-arrow-left[] Installing added plugins]

--- a/docs/en-gb/modules/plugins/pages/installing-added-plugins.adoc
+++ b/docs/en-gb/modules/plugins/pages/installing-added-plugins.adoc
@@ -2,13 +2,8 @@
 :author: team-plugin-core
 :keywords: plugin, extension, addon, plugin set, client, back end plugin set
 :description: Install plugins and link them to a client or user account.
+:page-pagination:
 :id: EGDTDOH
-
-[.previous-next-navigation]
-xref:plugins:adding-plugins-system.adoc#[icon:long-arrow-left[] Adding plugins to the system]
-xref:plugins:configuring-installed-plugins.adoc#[Configuring installed plugins icon:long-arrow-right[]]
-
-'''
 
 To use plugins, you first have to include them in a plugin set and deploy the set. <<creating-plugin-set, Create or copy>> a plugin set. In the plugin set, you can <<installing-plugins, install and deploy>> the plugin. Finally, to use the plugin productively, you have to link it to your <<linking-plugin-set, client>> or <<back-end-plugin-set, user account>>.
 
@@ -43,9 +38,3 @@ include::partial$plugin-set-verknuepfen-en_gb.adoc[]
 == Linking plugin sets to user accounts
 
 include::welcome:partial$backend-plugin-sets-en_gb.adoc[]
-
-'''
-
-[.previous-next-navigation]
-xref:plugins:adding-plugins-system.adoc#[icon:long-arrow-left[] Adding plugins to the system]
-xref:plugins:configuring-installed-plugins.adoc#[Configuring installed plugins icon:long-arrow-right[]]


### PR DESCRIPTION
The `page-pagination` attribute is a standard Antora implementation, so right now it's a bit different from what we had before.

1. There's no distinction between going forwards and backwards, both directions are displayed.
2. The pagination is based on the order in `nav.adoc`.
3. The pagination is only shown at the end of the page.

We can add more depth to this functionality if desired, I just went with the defaults for now because usage and interest were on the lower end.