### PR TITLE
fix: remove page alias

### DIFF
--- a/docs/en-gb/modules/app/pages/key-figures.adoc
+++ b/docs/en-gb/modules/app/pages/key-figures.adoc
@@ -1,7 +1,6 @@
 = Key performance indicators
 :author: team-app-bi
 :keywords: app statistics, app key figures, app sales statistics, app revenue
-:page-aliases: key-figures.adoc
 :id: GQEJK5F
 
 [#100]


### PR DESCRIPTION
The page alias must not equal the original page name