### PR TITLE
Bettina kaufland at pl

### DIFF
--- a/docs/de-de/modules/maerkte/pages/best-practices-kaufland-merkmalverknuepfung.adoc
+++ b/docs/de-de/modules/maerkte/pages/best-practices-kaufland-merkmalverknuepfung.adoc
@@ -11,7 +11,7 @@ Um bei Kaufland erfolgreich Artikel zu listen, werden von plentymarkets zwei Dat
 Aus verschiedenen Gründen kann es sinnvoll sein, die Produktdaten-Datei um bestimmte Attribute zu ergänzen. Entweder um Käufer:innen zusätzliche Informationen zu den Artikeln zu übermitteln (Materialangaben, Farbe etc.), oder um Pflichtangaben, die vom Gesetzgeber für bestimmte Produkte vorgeschrieben sind, zu übertragen (Gefahrenhinweise, Nährwertdeklarationen etc.).
 
 Diese Informationen lassen sich per Merkmal in der Produktdaten-Datei hinzufügen, für jedes Merkmal das mit link:https://www.Kaufland.de/[Kaufland^] verknüpft ist, wird in der product.csv eine neue Spalte hinzugefügt. +
-*_Hinweis:_* Das funktioniert nur bei der product., nicht bei der inventory.csv.
+*_Hinweis:_* Das funktioniert nur bei der product.csv, nicht bei der inventory.csv.
 
 [#200]
 == Wie wird die product.csv um ein weiteres Attribut erweitert?

--- a/docs/de-de/modules/maerkte/pages/best-practices-kaufland-rechnungen-hochladen.adoc
+++ b/docs/de-de/modules/maerkte/pages/best-practices-kaufland-rechnungen-hochladen.adoc
@@ -19,14 +19,14 @@ Wir empfehlen dir daher dringend, das automatische Hochladen von Rechnungen einz
 Bei Rechnungen für Kaufland musst du zwei Anpassungen auf dem Rechnungsdokument vornehmen.
 
 * Gib für die Zahlungsart *Kaufland* einen Hinweis ein. (<<#860, Wie?>>)
-* Deine Bankdaten dürfen nicht auf Rechnungen für Kaufland stehen. (<<#870, Wie?>>)
+* Blende deine Bankdaten auf Rechnungen für Kaufland aus. (<<#870, Wie?>>)
 
 Wie du diese Anpassungen vornimmst, wird im Folgenden beschrieben.
 
 [#860]
 === Hinweis für Zahlungsart Kaufland eingeben
 
-Auf allen Rechnungen für Kaufland muss der folgende Hinweis angegeben sein:
+Rechnungen für Kaufland müssen den folgenden Hinweis enthalten:
 
 [IMPORTANT]
 .Hinweise für Kaufland-Rechnungen
@@ -39,10 +39,14 @@ Geh wie unten beschrieben vor, um diesen Hinweis für die Zahlungsart Kaufland z
 [.instruction]
 Hinweis für Zahlungsart Kaufland eingeben:
 
+. Kopiere den oben angegebenen Hinweistext in die Zwischenablage.
 . Öffne das Menü *Einrichtung » Mandant » Standard » Standorte » Deutschland (Standard) » Dokumente » Rechnung » Tab: Vorlage*.
-. Gib im Bereich *Optionale Elemente unter Artikelpositionstabelle* für die Option *Zahlungshinweis* den oben angegebenen Hinweis bei der Zahlungsart *Kaufland* ein.
+. Navigiere im Bereich *Optionale Elemente unter Artikelpositionstabelle* zu der Einstellung *Zahlungshinweis*.
+. Gehe zu einem Eingabefeld, das noch keine Zahlungshinweise enthält.
+. Wähle aus der Dropdown-Liste *Zahlungsart: bitte wählen* dieses Eingabefelds die Option *Kaufland*.
+. Füge den kopierten Hinweistext für Kaufland-Rechnungen in das Eingabefeld ein.
 . Speichere (terra:save[]) die Einstellungen. +
-→ Der Hinweis wird nur bei Aufträgen, für die die Zahlungsart *Kaufland* gespeichert ist, in der Rechnung angezeigt.
+→ Der Hinweis wird nur auf Rechnungen für Aufträge angezeigt, für die die Zahlungsart *Kaufland* gespeichert ist.
 
 [#870]
 === Bankdaten auf Kaufland-Rechnungen ausblenden
@@ -58,7 +62,7 @@ Wie du die Bankdaten auf Kaufland-Rechnungen ausblendest kommt darauf an, wie du
 |Methode |Vorgehensweise
 
 | Bankdaten in PDF-Vorlage
-| Wenn du deine Bankdaten über eine xref:auftraege:auftragsdokumente.adoc#1700[PDF-Vorlage] auf Rechnungsdokumenten anzeigen lässt, xref:auftraege:auftragsdokumente.adoc#1700[erstelle] eine weitere PDF-Vorlage für Kaufland, die keine Bankdaten enthält. Speichere optional für diese PDF-Vorlage das Kaufland-Logo. Speichere diese PDF-Vorlage im Menü *Einrichtung » Mandant » Standard » Standorte » Deutschland (Standard) » Dokumente » Rechnung » Tab: PDF-Vorlage* für die Zahlungsart *Kaufland*. Deine Bankdaten werden dann nicht auf Kaufland-Rechnungen angezeigt. +
+| Wenn du deine Bankdaten über eine xref:auftraege:auftragsdokumente.adoc#1700[PDF-Vorlage] auf Rechnungsdokumenten anzeigen lässt, xref:auftraege:auftragsdokumente.adoc#1700[erstelle] eine weitere PDF-Vorlage für Kaufland, die keine Bankdaten enthält. Speichere optional für diese PDF-Vorlage das Kaufland-Logo. Speichere diese PDF-Vorlage im Menü *Einrichtung » Mandant » Standard » Standorte » Deutschland (Standard) » Dokumente » Rechnung » Tab: PDF-Vorlage* für die Zahlungsart *Kaufland* und die Sprache *Deutsch*. Deine Bankdaten werden dann nicht auf Kaufland-Rechnungen angezeigt. +
 
 image::maerkte:Kaufland_logo.png[]
 
@@ -97,7 +101,7 @@ Die in <<#ereignisaktion-rechnungen-kaufland>> aufgeführten Status und Filter d
 
 | *Filter 2*
 | *Auftrag &gt; Herkunft*
-| *Kaufland.de*
+| Auftragsherkünfte für Kaufland-Länderplattformen wählen, für die du diese Ereignisaktion nutzen willst. Wenn du die Ereignisaktion für alle Kaufland-Länderplattformen nutzen willst, wähle die Herkunft *102 Kaufland*.
 
 | *Aktion*
 | *Dokumente > Rechnung generieren*
@@ -126,12 +130,13 @@ Die in <<#ea-rechnungen-upload-kaufland>> aufgeführten Status und Filter dienen
 |Einstellung |Option |Auswahl
 
 | *Ereignis*
-|Ereignis wählen, zum Beispiel *Auftragsänderung: Statuswechsel* oder *Auftrag: Rechnung generiert*
+|Ereignis wählen, zum Beispiel *Auftragsänderung: Statuswechsel* +
+*_Hinweis:_* Wähle ein Ereignis, bei dem die Rechnung schon existiert. Das Ereignis *Auftrag: Rechnung generiert* wird nicht empfohlen, weil die Rechnung noch nicht vollständig generiert ist, wenn dieses Ereignis ausgelöst wird.
 |
 
 | *Filter*
 | *Auftrag &gt; Herkunft*
-| *Kaufland.de*
+| Auftragsherkünfte für Kaufland-Länderplattformen wählen, für die du diese Ereignisaktion nutzen willst. Wenn du die Ereignisaktion für alle Kaufland-Länderplattformen nutzen willst, wähle die Herkunft *102 Kaufland*.
 
 | *Aktion*
 | *Auftrag > Rechnung bei Kaufland.de hochladen*

--- a/docs/de-de/modules/maerkte/pages/kaufland-de-einrichten.adoc
+++ b/docs/de-de/modules/maerkte/pages/kaufland-de-einrichten.adoc
@@ -122,16 +122,16 @@ Die folgenden Felder werden beim Bestandsabgleich exportiert:
 * <<#kaufland-fbk, Aufträge, die von Kaufland abgewickelt werden (FbK = Fulfillment by Kaufland)>> werden mit der Auftragsherkunft *170.01 Kaufland FBK DE* in plentymarkets importiert.
 
 [IMPORTANT]
-.Auftragsimport für Tschechien und die Slowakei manuell anstoßen
+.Auftragsimport für Österreich, Polen, Tschechien und die Slowakei manuell anstoßen
 ====
-Momentan kann es passieren, dass der Auftragsimport für Aufträge der Marktplätze Kaufland CZ (Tschechien) und Kaufland SK (Slowakei) nicht funktioniert. Deshalb muss der Auftragsimport manuell angestoßen werden. Dazu müssen die Einstellungen für Kaufland neu gespeichert werden. Führe dazu die folgenden Schritte aus:
+Momentan kann es passieren, dass der Auftragsimport für Aufträge der Marktplätze Kaufland AT (Österreich), Kaufland CZ (Tschechien), Kaufland PL (Polen) und Kaufland SK (Slowakei) nicht funktioniert. Deshalb muss der Auftragsimport manuell angestoßen werden. Dazu müssen die Einstellungen für Kaufland neu gespeichert werden. Führe dazu die folgenden Schritte aus:
 
 [.instruction]
-Auftragsimport für CZ und SK manuell anstoßen:
+Auftragsimport für AT, CZ, PL und SK manuell anstoßen:
 
 . Öffne das Menü *Einrichtung » Märkte » Kaufland » Einstellungen » [Kaufland-Konto öffnen]*.
 . Klicke oben links auf *Speichern* (terra:save[]). +
-→ Die Konfiguration für die Marktplätze CZ und SK wird gespeichert.
+→ Die Konfiguration für die Marktplätze AT, CZ, PL und SK wird gespeichert.
 ====
 
 [#market-setup]
@@ -142,7 +142,7 @@ Richte den Marktplatz in plentymarkets ein.
 [TIP]
 .Kaufland-Länderplattformen
 ====
-Mit plentymarkets kannst du auf den Kaufland-Länderplattformen Kaufland.de, Kaufland.cz und Kaufland.sk verkaufen.
+Mit plentymarkets kannst du auf den Kaufland-Länderplattformen Kaufland.de, Kaufland.at, Kaufland.cz, Kaufland.pl und Kaufland.sk verkaufen.
 ====
 
 [#einstellungen-kaufland]
@@ -413,7 +413,7 @@ Lager verknüpfst du über die Einstellung *Lager zuordnen* im Menü *Einrichtun
 
 :market: Kaufland
 :referrer: Kaufland.de
-:referrer-option: pass:quotes[Option *Kaufland.de* mit der ID *102*]
+:referrer-option: pass:quotes[Option *Kaufland.de* mit der ID *102.01*]
 
 include::partial$auftragsherkunft-aktivieren.adoc[]
 
@@ -494,7 +494,9 @@ include::partial$variantenverfuegbarkeit.adoc[]
 
 *_Hinweis:_* Du musst deine Varianten nur mit Kaufland-Produktkategorien verknüpfen, wenn du Artikel per <<#catalogue-export, Katalogexport>> an Kaufland überträgst.
 
-Wenn du mit dem Assistenten *Kaufland - Kataloge erstellen* einen Katalog für Kaufland erstellt hast, wird in deinem plentymarkets System die Eigenschaft *Kaufland.de-Kategorie* erstellt. Mit dieser Eigenschaft legst du fest, in welcher Kategorie deine Varianten auf Kaufland angeboten werden.
+Wenn du mit dem Assistenten *Kaufland - Kataloge erstellen* einen Katalog für Kaufland.de erstellt hast, wird in deinem plentymarkets System die Eigenschaft *Kaufland.de-Kategorie* erstellt. Mit dieser Eigenschaft legst du fest, in welcher Kategorie deine Varianten auf Kaufland angeboten werden.
+
+*_Hinweis:_* Wenn du deine Artikel auf anderen Kaufland-Länderplattformen verkaufen willst, musst du für jede gewünschte Länderplattform eigene Kataloge erstellen. Wähle hierzu im Assistenten *Kaufland - Kataloge erstellen* die Kaufland-Länderplattform, auf der du deine Artikel anbieten möchtest. In deinem plentymarkets System wird entsprechend die Eigenschaft *Kaufland.at-Kategorie*, *Kaufland.cz-Kategorie*, *Kaufland.pl-Kategorie* oder *Kaufland.sk-Kategorie* erstellt. Die nächsten Schritte erfolgen dann für die Kaufland-Kategorie der jeweils gewählten Länderplattform.
 
 Im Assistenten *Kaufland - Kataloge erstellen* wählst du für jeden Katalog eine Kaufland-Produktkategorie. Jede dieser Produktkategorien wird als Auswahlwert zu der Eigenschaft *Kaufland.de-Kategorie* hinzugefügt.
 
@@ -768,23 +770,24 @@ Größeneinheit als eigenen Wert angeben:
 [#sprache-produktdaten]
 ===== Sprache für Produktdaten
 
-Für den Verkauf auf den internationalen Märkten Kaufland CZ (Tschechien) und Kaufland SK (Slowakei) wurde das Feld *Sprache der plentymarkets Produktdaten* hinzugefügt. +
-Dieses Feld ist kein Pflichtfeld; es ist jedoch für die Kaufland-Länderplattformen CZ und SK relevant, wenn die Produktdaten in plentymarkets auf Deutsch gepflegt werden.
+Für den Verkauf auf den internationalen Märkten Kaufland CZ (Tschechien), Kaufland PL (Polen) und Kaufland SK (Slowakei) wurde das Feld *Sprache der plentymarkets Produktdaten* hinzugefügt. +
+Dieses Feld ist kein Pflichtfeld; es ist jedoch für die Kaufland-Länderplattformen CZ, PL und SK relevant, wenn die Produktdaten in plentymarkets auf Deutsch gepflegt werden.
 
 * Wenn das Feld *Sprache der plentymarkets Produktdaten* nicht zugeordnet wird und leer bleibt, dann geht das System davon aus, dass die Produktdaten in plentymarkets in der Sprache des jeweiligen Marktplatzes gepflegt werden.
 
 * Wenn die Produktdaten in plentymarkets auf Deutsch gepflegt werden, muss dieses Feld also zugeordnet werden, damit die Produktdaten bei der Übertragung in die Sprache des Marktplatzes übersetzt werden.
 
-* Wenn die *Sprache der plentymarkets Produktdaten* im Katalog auf `de` eingestellt ist, prüft das System anhand der EAN, ob es bereits ein Produkt mit der Sprache Deutsch gibt. Wenn ja, wird dazu ein Angebot für den Marktplatz *SK* oder *CZ* erstellt und die Produktdaten werden in die jeweilige Sprache übersetzt. +
+* Wenn die *Sprache der plentymarkets Produktdaten* im Katalog auf `de` eingestellt ist, prüft das System anhand der EAN, ob es bereits ein Produkt mit der Sprache Deutsch gibt. Wenn ja, wird dazu ein Angebot für den Marktplatz *CZ*, *PL* oder *SK* erstellt und die Produktdaten werden in die jeweilige Sprache übersetzt. +
 Wenn es kein Produkt mit der Sprache Deutsch gibt, dann wird das Produkt erst auf Deutsch erstellt und anschließend in die jeweilige Sprache übersetzt.
 
-* Produktdaten werden auf den Länderplattformen Kaufland CZ und Kaufland SK auch aktualisiert, wenn die Produktsprache entweder auf `cz` _oder_ `sk` eingestellt ist. Die Sprache im Katalog muss also nicht zwingend mit der Sprache für die jeweilige Länderplattform übereinstimmen, damit Produkte aktualisiert werden.
+* Produktdaten werden auf den Länderplattformen Kaufland CZ, Kaufland PL und Kaufland SK auch aktualisiert, wenn die Produktsprache entweder auf `cz` _oder_ `pl` _oder_ `sk` eingestellt ist. Die Sprache im Katalog muss also nicht zwingend mit der Sprache für die jeweilige Länderplattform übereinstimmen, damit Produkte aktualisiert werden.
 
 * *_erlaubte Werte für die Zuordnung:_* +
 
 `de` = Produktdaten sind auf Deutsch gepflegt und werden in die Sprache des Katalogs übersetzt +
-`sk` = Produktdaten sind in Slowakisch gepflegt und werden in Slowakisch übertragen +
-`cz` = Produktdaten sind in Tschechisch gepflegt und werden in Tschechisch übertragen
+`cz` = Produktdaten sind in Tschechisch gepflegt und werden in Tschechisch übertragen +
+`pl` = Produktdaten sind in Polnisch gepflegt und werden in Polnisch übertragen +
+`sk` = Produktdaten sind in Slowakisch gepflegt und werden in Slowakisch übertragen
 
 [#activate-catalogue]
 ==== Katalogexport aktivieren

--- a/docs/de-de/modules/maerkte/partials/kaufland-recommended-mappings.adoc
+++ b/docs/de-de/modules/maerkte/partials/kaufland-recommended-mappings.adoc
@@ -76,7 +76,7 @@ _oder_
 | ja
 | * *Verkaufspreis »* [Verkaufspreis für Kaufland wählen]
 
-*_Hinweis:_* In Katalogen für die Länderplattform Kaufland.cz (Tschechien) muss beim Verkaufspreis die Währung auf *Tschechische Krone* umgestellt werden.
+*_Hinweis:_* In Katalogen für die Länderplattform Kaufland.cz (Tschechien) muss beim Verkaufspreis die Währung auf *Tschechische Krone* umgestellt werden. In Katalogen für die Länderplattform Kaufland.pl (Polen) muss beim Verkaufspreis die Währung auf *Zloty* umgestellt werden.
 
 | Mindestpreis
 | ja

--- a/docs/en-gb/modules/markets/pages/best-practices-kaufland-linking-characteristics.adoc
+++ b/docs/en-gb/modules/markets/pages/best-practices-kaufland-linking-characteristics.adoc
@@ -1,6 +1,6 @@
 = Best practice: Linking characteristics to attributes
 :author: team-plenty-channel
-:keywords: Kaufland, Kaufland.de, real.de, Multi-Channel, inventory.csv, product.csv, Kaufland inventory.csv, Kaufland product.csv, Kaufland attribute matching, Kaufland characteristic matching, Kaufland product data file
+:keywords: inventory.csv, product.csv, real inventory.csv, real product.csv, real attribute matching, real characteristic matching, real product data file, Kaufland, Kaufland.de, real.de, Multi-Channel,  Kaufland inventory.csv, Kaufland product.csv, Kaufland attribute matching, Kaufland characteristic matching, Kaufland product data file
 :page-aliases: best-practices-kaufland-linking-properties.adoc
 :description: This best practice teaches you how to link plentymarkets characteristics with Kaufland attributes. You can use attributes to provide more detailed information about the item.
 

--- a/docs/en-gb/modules/markets/pages/best-practices-kaufland-uploading-invoices.adoc
+++ b/docs/en-gb/modules/markets/pages/best-practices-kaufland-uploading-invoices.adoc
@@ -19,14 +19,14 @@ As such, we strongly recommend that you set up this event procedure. Find out ho
 You have to modify the invoices for Kaufland. Two adjustments have to be made:
 
 * Enter a note for the payment method *Kaufland*. (<<#860, How?>>)
-* Your bank details must not appear on invoices for Kaufland. (<<#870, How?>>)
+* Hide your bank details on invoices for Kaufland. (<<#870, How?>>)
 
 How to carry out these adjustments is described below.
 
 [#860]
 === Entering a note for the Kaufland payment method:
 
-The following note must appear on all Kaufland invoices:
+Invoices for Kaufland need to show the following payment note:
 
 [IMPORTANT]
 .Note for Kaufland invoices
@@ -39,10 +39,14 @@ Proceed as described below to save this note for the Kaufland payment method.
 [.instruction]
 Entering a note for the Kaufland payment method:
 
+. Copy the note text above to the clipboard.
 . Go to *Setup » Client » Standard » Locations » Germany (standard) » Documents » Invoice » Tab: Template*.
-. In the *Optional elements below stock unit table* area, enter the note given above for the *Payment instruction* setting for the payment method *Kaufland*.
+. Navigate to the area *Optional elements below stock unit table*, to the setting *Payment instruction*.
+. Find a field that does not contain any payment instructions.
+. From the drop-down list *Payment method: please select* of this field, select the option *Kaufland*.
+. Paste the copied text for Kaufland invoices into the input field.
 . Save (terra:save[]) the settings. +
-→ The note only appears on the invoices for orders with the payment method *Kaufland*.
+→ The note only appears on invoices for orders with the payment method *Kaufland*.
 
 [#870]
 === Hiding bank details on Kaufland invoices
@@ -58,9 +62,9 @@ How you hide your bank details on Kaufland invoices depends on how you show your
 |Method |Instructions
 
 | Bank details in PDF template
-| If you use a xref:orders:order-documents.adoc#1700[PDF template] to display your bank details on an invoice, then create another PDF template for Kaufland that does not contain bank details. You can also save the Kaufland logo for this PDF template. To save this PDF template for the payment method *Kaufland*, go to *Setup » Client » Standard » Locations » Germany (standard) » Documents » Invoice » Tab: PDF template*. Your bank details are not displayed on invoices for Kaufland. +
+| If you use a xref:orders:order-documents.adoc#1700[PDF template] to display your bank details on an invoice, then create another PDF template for Kaufland that does not contain bank details. You can also save the Kaufland logo for this PDF template. Go to *Setup » Client » Standard » Locations » Germany (standard) » Documents » Invoice » Tab: PDF template* and save this PDF template for the payment method *Kaufland* and the language *German*. Your bank details are not displayed on invoices for Kaufland. +
 
-image::markets:kaufland_logo.jpg[]
+image::markets:kaufland_logo_en.png[]
 
 | Bank details in payment instructions
 | If you entered your bank details in the *Setup » Client » Standard » Locations » Germany (standard) » Documents » Invoice » Tab: Template* menu for the *Payment instruction* setting, then you do not need to carry out any further settings. If you use this method, your bank details are not displayed on Kaufland invoices.
@@ -97,7 +101,7 @@ The status and filters listed in <<#event-procedure-invoices-kaufland>> only ser
 
 | *Filter 2*
 | *Order > Referrer*
-| *Kaufland.de*
+| Select the order referrers for the Kaufland country platforms that you want to use this event procedure for. If you want to use the event procedure for all Kaufland country platforms, then select the order referrer *102 Kaufland*.
 
 | *Procedure*
 | *Documents > Generate invoice*
@@ -126,12 +130,13 @@ The statuses and filters in <<#event-procedure-invoice-upload-kaufland>> only se
 |Setting |Option |Selection
 
 | *Event*
-| Select an event, for example *Order change: Status change*, *Documents: Invoice generated*.
+|Select an event, for example *Order change: Status change*. +
+*_Note:_* Select an event that is triggered when the invoice already exists. The event *Order: Invoice generated* is not recommended. This is because the event is triggered before the invoice generation is completed.
 |
 
 | *Filter*
 | *Order > Referrer*
-| *Kaufland.de*
+| Select the order referrers for the Kaufland country platforms that you want to use this event procedure for. If you want to use the event procedure for all Kaufland country platforms, then select the order referrer *102 Kaufland*.
 
 | *Procedure*
 | *Order > Upload invoice to Kaufland.de*

--- a/docs/en-gb/modules/markets/pages/kaufland-setup.adoc
+++ b/docs/en-gb/modules/markets/pages/kaufland-setup.adoc
@@ -47,16 +47,16 @@ If you export data to Kaufland using catalogues, then data are exchanged with Ka
 | once a day
 
 | Updating offers
-| Hourly
+| hourly
 
 | Deleting offers
-| Hourly
+| hourly
 
 | Updating products
 | once a day
 
 | Status of product creation
-| Hourly
+| hourly
 |===
 
 [#data-exchange-old-export]
@@ -71,10 +71,10 @@ If you export data to Kaufland using the old export, then data are exchanged wit
 |Data |Interval
 
 | Price synchronisation
-| Hourly
+| hourly
 
 | Stock synchronisation
-| Hourly
+| hourly
 
 The following fields are exported during stock synchronisation:
 
@@ -114,7 +114,7 @@ The following fields are exported during stock synchronisation:
 [TIP]
 .Reserve stock for orders with the payment method cash in advance
 ====
-*_Important:_* No stock is reserved for orders in status *[1] Invalid data* by default. To make sure that stock is reserved for these orders, go to *Setup » Orders » Settings*. Go to the setting *Status for order reservation (Reservation of stocks)*. For the option *to*, select the status *[1] Incomplete data*. In the drop-down list to the far right, select the option *All orders*.
+*_Important:_* No stock is reserved for orders in status *[1] Incomplete data* by default. To make sure that stock is reserved for these orders, go to *Setup » Orders » Settings*. Go to the setting *Status for order reservation from* and select the status *[1] Incomplete data*. Go to the setting *Status for order reservation to* and select the status up to which stocks are to be reserved.
 ====
 
 * When the order status on Kaufland changes after 15 minutes, the order automatically moves to status *[5] Cleared for shipping* in plentymarkets. All missing order data is added to the order.
@@ -122,16 +122,16 @@ The following fields are exported during stock synchronisation:
 * <<#kaufland-fbk, Orders that are processed by Kaufland (FbK = Fulfillment by Kaufland)>> are imported into plentymarkets with the order referrer *170.01 Kaufland FBK DE*.
 
 [IMPORTANT]
-.Trigger order import for Kaufland CZ and Kaufland SK orders manually
+.Trigger order import for Kaufland AT, Kaufland PL, Kaufland CZ and Kaufland SK orders manually
 ====
-The order import for orders generated on the markets Kaufland CZ (Czech Republic) and Kaufland SK (Slovakia) does not work properly at present. Therefore, you have to trigger the order import manually. To do so, save the settings for Kaufland again. To save the settings, proceed as follows:
+At present, it may happen that the order import for orders generated on the markets Kaufland AT (Austria), Kaufland CZ (Czech Republic), Kaufland PL (Poland) and Kaufland SK (Slovakia) does not work properly. Therefore, you have to trigger the order import manually. To do so, save the settings for Kaufland again. To save the settings, proceed as follows:
 
 [.instruction]
-Triggering the order import for CZ and SK orders manually:
+Triggering the order import for AT, CZ, PL and SK orders manually:
 
 . Go to *Setup » Markets » Kaufland » Settings » [Open Kaufland account]*.
 . In the top left corner, click on *Save* (terra:save[]). +
-→ The configuration for the markets CZ and SK is saved.
+→ The configuration for the markets AT, CZ, PL and SK is saved.
 ====
 
 [#market-setup]
@@ -142,7 +142,7 @@ Set up the market in plentymarkets.
 [TIP]
 .Kaufland country platforms
 ====
-With plentymarkets, you can sell your items on the Kaufland platforms Kaufland.de, Kaufland.cz, and Kaufland.sk.
+With plentymarkets, you can sell your items on the Kaufland platforms Kaufland.de, Kaufland.at, Kaufland.cz, Kaufland.pl, and Kaufland.sk.
 ====
 
 [#settings-kaufland]
@@ -282,7 +282,7 @@ First, click on *Update Kaufland shipping groups* (material:refresh[]) so that t
 If an item has more than one shipping profile, the shipping profile with the lowest category and the highest priority is exported. The category and the priority of a shipping profile are configured within *Setup » Orders » Shipping » Settings » Tab: Shipping profiles* in the *Base* tab of each shipping profile.
 
 | *Match warehouses*
-a| Warehouses located outside the EU have to be linked with a Kaufland warehouse. Use the setting *Match warehouses* for this. Here, all of your plentymarkets warehouses of the type *Sales* are listed. Select your warehouses and link each of them to the correspondent Kaufland warehouse. This way, the stock of your warehouses is linked to the Kaufland warehouses. +
+a| Warehouses located outside the EU have to be mapped with a Kaufland warehouse. Use the setting *Match warehouses* for this. Here, all of your plentymarkets warehouses of the type *Sales* are listed. Select your warehouses and map each of them to the correspondent Kaufland warehouse. This way, the stock of your warehouses is mapped to the Kaufland warehouses. +
 *_Note:_* This setting is not relevant if your warehouses are within the EU. +
 
 * *–* = The warehouse is linked to the Kaufland default warehouse.
@@ -413,7 +413,7 @@ Assign warehouses with the option *Match warehouses* in the menu *Setup » Marke
 
 :market: Kaufland
 :referrer: Kaufland.de
-:referrer-option: pass:quotes[option *Kaufland.de* with ID *102*]
+:referrer-option: pass:quotes[option *Kaufland.de* with ID *102.01*]
 
 include::partial$activate-referrer.adoc[]
 
@@ -452,7 +452,7 @@ Defining a barcode for Kaufland:
 
 . Go to *Setup » Item » Barcode*.
 . Open the barcode.
-. Activate the referrer *Kaufland*.
+. Activate the referrer *Kaufland.de*.
 . Save (terra:save[]) the settings. +
 *_Tip:_* Is this barcode already linked to your variations? If not, don’t forget <<#save-barcode, to link the barcode to your variations and to save a code>>.
 
@@ -487,14 +487,16 @@ Continue with preparing your variations.
 
 include::partial$variation-availability.adoc[]
 
-// Web API required!
+// Web API required! But not for catalogues
 
 [#link-variations-to-product-category]
 === Linking variations to a Kaufland product category
 
 *_Note:_* You only have to link your variations to Kaufland product categories if you use the <<#catalogue-export, catalogue export>> to transfer items to Kaufland.
 
-After you created a catalogue for Kaufland with the assistant *Kaufland - Creating catalogues*, the property *Kaufland.de category* is created in your plentymarkets system. With this property, you define in which category your variations are offered on Kaufland.
+After you created a catalogue for Kaufland.de with the assistant *Kaufland - Creating catalogues*, the property *Kaufland.de category* is created in your plentymarkets system. With this property, you define in which category your variations are offered on Kaufland.
+
+*_Note:_* If you want to sell your items on other Kaufland country platforms, you have to create separate catalogues for each country platform. Select the Kaufland country platform on which you want to offer your items in the *Kaufland - Creating catalogues* assistant. The corresponding property *Kaufland.at category*, *Kaufland.cz category*, *Kaufland.pl category* or *Kaufland.sk category* will be created in your plentymarkets system. The next steps are performed for the Kaufland category of the selected country platform.
 
 In the assistant *Kaufland - Creating catalogues*, you select a Kaufland product category for each catalogue that you create. Each of these product categories is added as a selection value to the property *Kaufland.de category*.
 
@@ -571,12 +573,12 @@ This chapter describes how to export your item data to {market} using the old ex
 [#600]
 ==== Linking categories
 
-Link your plentymarkets categories to the Kaufland.de categories in order to display your items in these categories. Further items from the linked category are assigned automatically.
+Link your plentymarkets categories to the Kaufland categories in order to display your items in these categories. Further items from the linked category are assigned automatically.
 
 [.instruction]
 Linking categories:
 
-. Go to *Setup » Markets » Kaufland.de » Category link*.
+. Go to *Setup » Markets » Kaufland » Category link*.
 . Click on *Search* (icon:search[role="blue"]). +
 → The *Select category* window opens.
 . Select the Kaufland category that best matches your plentymarkets category.
@@ -627,7 +629,7 @@ Creating a characteristic:
 . Enter a name in the *Webshop* field.  +
 → This name is used in the item overview of the plentyShop.
 . Select the *Characteristic type*.
-. Activate the option *Kaufland.de*.
+. Activate the option *Kaufland*.
 . Save (terra:save[]) the settings.
 
 For further information about linking characteristics with Kaufland, refer to the best practice page xref:markets:best-practices-kaufland-linking-characteristics.adoc#[Linking characteristics to attributes].
@@ -768,23 +770,24 @@ Specifying the size unit as own value:
 [#language-product-data]
 ===== Language of product data
 
-The field *Language of plentymarkets product data* was added to the Kaufland catalogues. +
-This field is not mandatory. However, it is relevant for the Kaufland country platforms CZ (Czech Republic) and SK (Slovakia) if the product data in plentymarkets are saved in German.
+For sales on the international markets Kaufland CZ (Czech Republic), Kaufland PL (Poland) and Kaufland SK (Slovakia), the field *Language of plentymarkets product data* was added to the Kaufland catalogues. +
+This field is not mandatory. However, it is relevant for the Kaufland country platforms CZ (Czech Republic), PL (Poland), and SK (Slovakia) if the product data in plentymarkets are saved in German.
 
 * If the field *Language of plentymarkets product data* is not mapped and remains empty, then the system assumes that the product data in plentymarkets are saved in the language of each market.
 
 * Thus, if the product data in plentymarkets are saved in German, this field must be mapped so that the product data will be translated into the market’s language when they are exported.
 
-* If the *Language of plentymarkets product data* is set to `de` in the catalogue, then the system checks using the EAN whether a product with the language German already exists. If yes, an offer for the market *SK* or *CZ* is created and the product data are translated into the appropriate language. +
+* If the *Language of plentymarkets product data* is set to `de` in the catalogue, then the system checks using the EAN whether a product with the language German already exists. If yes, an offer for the market *CZ*, *PL* or *SK* is created and the product data are translated into the appropriate language. +
 If no product with the language German exists, then the product is created in German and translated into the appropriate language afterwards.
 
-* Product data will also be updated on the country platforms Kaufland CZ and Kaufland SK if the product language is either set to `cz` _or_ `sk`. Hence, the language in the catalogue does not necessarily have to be the language of the country platform. Products will be updated anyway.
+* Product data will also be updated on the country platforms Kaufland CZ, Kaufland PL, and Kaufland SK if the product language is either set to `cz` _or_ `pl` _or_ `sk`. Hence, the language in the catalogue does not necessarily have to be the language of the country platform. Products will be updated anyway.
 
 * *_allowed values:_* +
 
 `de` = product data are saved in German and are translated into the language of the catalogue +
-`sk` = product data are saved in Slovak and are transferred in Slovak +
-`cz` = product data are saved in Czech and are transferred in Czech
+`cz` = product data are saved in Czech and are transferred in Czech +
+`pl` = product data are saved in Polish and are transferred in Polish +
+`sk` = product data are saved in Slovak and are transferred in Slovak
 
 [#activate-catalogue]
 ==== Activating the catalogue export
@@ -856,7 +859,7 @@ How you hide bank details on {market} invoices depends on how your bank details 
 
 [[image-kaufland-logo]]
 .Kaufland logo
-image::markets:kaufland_logo.png[]
+image::markets:kaufland_logo_en.png[]
 
 [#automate-orders]
 == Automating order processing
@@ -906,7 +909,7 @@ _or_
 | *Procedure*
 | *Plugin*
 | *Send shipping confirmation to Kaufland.de* +
-*_Note:_* If no shipping confirmation could be sent to {market}, the order is moved to the status that you selected for the option *Order status for orders with failed shipping confirmations*. Go to *Setup » Markets » Kaufland.de » Settings* to set this option.
+*_Note:_* If no shipping confirmation could be sent to {market}, the order is moved to the status that you selected for the option *Order status for orders with failed shipping confirmations*. Go to *Setup » Markets » Kaufland » Settings* to set this option.
 
 * <<#no-shipping-confirmation, How to deal with orders in this status>>
 |===
@@ -1074,7 +1077,7 @@ _or_
 | *Procedure*
 | *Order*
 | *Send in fulfilment confirmation to Kaufland.de* +
-*_Note:_* If no in fulfilment confirmation could be sent to {market}, the order is moved to the status that you selected for the option *Order status for orders with failed in fulfilment confirmations*. Go to *Setup » Markets » Kaufland.de » Settings* to set this option.
+*_Note:_* If no in fulfilment confirmation could be sent to {market}, the order is moved to the status that you selected for the option *Order status for orders with failed in fulfilment confirmations*. Go to *Setup » Markets » Kaufland » Settings* to set this option.
 |===
 ////
 

--- a/docs/en-gb/modules/markets/partials/kaufland-recommended-mappings.adoc
+++ b/docs/en-gb/modules/markets/partials/kaufland-recommended-mappings.adoc
@@ -76,7 +76,7 @@ _or_
 | yes
 | * *Sales price »* [Select sales price for Kaufland]
 
-*_Note:_* In catalogues for the country platform Kaufland.cz (Czech Republic), you have to set the *Currency Czech koruna*.
+*_Note:_* In catalogues for the country platform Kaufland.cz (Czech Republic), you have to set the *Currency Czech koruna*. In catalogues for the country platform Kaufland.pl (Poland), you have to set the *Currency Zloty*.
 
 | Minimum price
 | yes


### PR DESCRIPTION
Added information about country platforms AT and PL to Kaufland pages:
- Kaufland setup (Chapter 3: Trigger order import for Kaufland CZ and Kaufland SK orders manually, Chapter 4: Kaufland country platforms, Chapter 4.4: Order referrer (changed order referrer ID 102 for Kaufland.de in point 3 to 102.01), Chapter 6.2.4.3: Language of product data)
Chapter 5.2: Linking variations to a Kaufland product category. Add, that for each country a category is created.
- recommended mappings (partial) (Added that sales prices for PL needs to be adjusted in Zloty.)
- Best practices: Kaufland linking characteristics (correct typo in German version (.csv is missing))
- Best practices: Kaufland uploading invoices (Changed wording in "Editing the invoice" point 2, changed wording in "Entering a note for the Kaufland payment method", adjusted instruction in "Entering a note for the Kaufland payment method", added language German in "Hiding bank details on Kaufland invoices", add country specific referrer info in "Automatically creating invoices", added country specific referrer info and notice in "Automatically uploading invoices")
- Fixed minor typos
- Fixed broken Kaufland logo image in English version